### PR TITLE
Add the option to define multiple notification percentages

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,15 +80,18 @@ Here's an example of the configuration file:
 
 ```
 # Lowkey Configuration File
-# Set the critical battery level (in percentage)
-critical_bat=25
+# Set the critical battery levels (in percentages)
+critical_bat=5, 10, 15
+# Set the low battery levels (in percentages)
+low_bat=20, 30
 # Set the battery number to monitor
 bat=1
 ```
 
 ### Configuration Options
 
-- `critical_bat`: This sets the battery percentage at which lowkey will send a critical battery notification. In the example, it's set to 25%.
+- `critical_bat`: This sets the battery percentages at which lowkey will send critical battery notifications. In the example, it's set to 5%, 10%, and 15%.
+- `low_bat`: This sets the battery percentages at which lowkey will send low battery notifications. In the example, it's set to 20% and 30%.
 - `bat`: This specifies which battery to monitor if your system has multiple batteries. It's set to 1 in the example, which typically corresponds to the main battery.
 
 ### Editing the Configuration
@@ -100,13 +103,14 @@ To modify the configuration:
    nano ~/.config/lowkey/config
    ```
 
-2. Adjust the values as needed. For example, to change the critical battery level to 20% and monitor battery 2:
+2. Adjust the values as needed. For example, to change the critical battery levels to 10%, 15%, and 20%, and the low battery levels to 25% and 35%, and monitor battery 2:
    ```
-   critical_bat=20
-   bat=1
+   critical_bat=10, 15, 20
+   low_bat=25, 35
+   bat=2
    ```
 
 3. Save the file and exit the editor.
 
-Remember to use whole numbers for the percentage and battery number. If you're unsure about which battery number to use, you can check the available batteries in your system by looking at the contents of the `/sys/class/power_supply/` directory.
+Remember to use whole numbers for the percentages and battery number. If you're unsure about which battery number to use, you can check the available batteries in your system by looking at the contents of the `/sys/class/power_supply/` directory.
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,16 +5,19 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <vector>
+#include <sstream>
 
 struct Config {
-  int criticalLevel;
+  std::vector<int> criticalBatteryLevels;
+  std::vector<int> lowBatteryLevels;
   int batteryNumber;
 
-  Config() : criticalLevel(15), batteryNumber(1) {} // Default values
+  Config() : batteryNumber(1) {} // Default values
 };
 
-std::string getBatteryStatus(int &capacity, int criticalLevel,
-                             int batteryNumber) {
+std::string getBatteryStatus(int &capacity, const std::vector<int> &criticalLevels,
+                             const std::vector<int> &lowLevels, int batteryNumber) {
   std::string batteryPath = "/sys/class/power_supply/BAT" +
                             std::to_string(batteryNumber) + "/capacity";
   std::ifstream capacityFile(batteryPath);
@@ -23,18 +26,29 @@ std::string getBatteryStatus(int &capacity, int criticalLevel,
     capacityFile >> capacity;
   }
 
-  std::string status;
-  if (capacity < criticalLevel) {
-    status = "Critical";
-  } else {
-    status = "Normal";
+  std::string status = "Normal";
+  for (int level : criticalLevels) {
+    if (capacity < level) {
+      status = "Critical";
+      break;
+    }
+  }
+
+  if (status == "Normal") {
+    for (int level : lowLevels) {
+      if (capacity < level) {
+        status = "Low";
+        break;
+      }
+    }
   }
 
   return status;
 }
 
-void sendNotification() {
-  system("notify-send -u critical 'Low Battery' 'Charge soon'");
+void sendNotification(const std::string &message) {
+  std::string command = "notify-send -u critical 'Battery Notification' '" + message + "'";
+  system(command.c_str());
 }
 
 void sendBatteryFull() {
@@ -55,14 +69,23 @@ void writeLockState(const std::string &lockFilePath, bool lockState) {
   lockFile << lockState;
 }
 
+std::vector<int> parseBatteryLevels(const std::string &levelsStr) {
+  std::vector<int> levels;
+  std::stringstream ss(levelsStr);
+  std::string level;
+  while (std::getline(ss, level, ',')) {
+    levels.push_back(std::stoi(level));
+  }
+  return levels;
+}
+
 Config readConfig(const std::string &configFilePath) {
   Config config;
   boost::program_options::options_description desc("Allowed options");
-  desc.add_options()("critical_bat",
-                     boost::program_options::value<int>(&config.criticalLevel),
-                     "Critical battery level")(
-      "bat", boost::program_options::value<int>(&config.batteryNumber),
-      "Battery number");
+  desc.add_options()
+    ("critical_bat", boost::program_options::value<std::string>()->default_value("5,10,15"), "Critical battery levels")
+    ("low_bat", boost::program_options::value<std::string>()->default_value("20,30"), "Low battery levels")
+    ("bat", boost::program_options::value<int>(&config.batteryNumber), "Battery number");
 
   boost::program_options::variables_map vm;
   std::ifstream configFile(configFilePath);
@@ -71,6 +94,9 @@ Config readConfig(const std::string &configFilePath) {
         boost::program_options::parse_config_file(configFile, desc), vm);
     boost::program_options::notify(vm);
   }
+
+  config.criticalBatteryLevels = parseBatteryLevels(vm["critical_bat"].as<std::string>());
+  config.lowBatteryLevels = parseBatteryLevels(vm["low_bat"].as<std::string>());
 
   return config;
 }
@@ -84,22 +110,26 @@ int main() {
 
   Config config = readConfig(configFilePath);
 
-  int criticalLevel = config.criticalLevel;
+  const std::vector<int> &criticalLevels = config.criticalBatteryLevels;
+  const std::vector<int> &lowLevels = config.lowBatteryLevels;
   int batteryNumber = config.batteryNumber;
   bool lockState = readLockState(lockFilePath);
 
   int capacity = 0;
-  std::string status = getBatteryStatus(capacity, criticalLevel, batteryNumber);
+  std::string status = getBatteryStatus(capacity, criticalLevels, lowLevels, batteryNumber);
 
-  logFile << "Battery Capacity: " << capacity << "%, Status: " << status
-          << "\n";
+  logFile << "Battery Capacity: " << capacity << "%, Status: " << status << "\n";
   logFile.flush();
 
-  if (capacity < criticalLevel && !lockState) {
-    sendNotification();
+  if (status == "Critical" && !lockState) {
+    sendNotification("Critical battery level reached. Charge soon.");
     lockState = true;
     writeLockState(lockFilePath, lockState);
-  } else if (capacity >= criticalLevel && lockState && capacity < 100) {
+  } else if (status == "Low" && !lockState) {
+    sendNotification("Low battery level reached. Consider charging.");
+    lockState = true;
+    writeLockState(lockFilePath, lockState);
+  } else if (capacity >= *std::min_element(criticalLevels.begin(), criticalLevels.end()) && lockState && capacity < 100) {
     lockState = false;
     writeLockState(lockFilePath, lockState);
   } else if (capacity == 100 && !lockState) {
@@ -108,10 +138,18 @@ int main() {
     writeLockState(lockFilePath, lockState);
   }
 
-  std::cout << "Battery Capacity: " << capacity << "%, Status: " << status
-            << std::endl;
+  std::cout << "Battery Capacity: " << capacity << "%, Status: " << status << std::endl;
   std::cout << "lockState: " << lockState << std::endl;
-  std::cout << "Critical Level: " << criticalLevel << std::endl;
+  std::cout << "Critical Levels: ";
+  for (int level : criticalLevels) {
+    std::cout << level << " ";
+  }
+  std::cout << std::endl;
+  std::cout << "Low Levels: ";
+  for (int level : lowLevels) {
+    std::cout << level << " ";
+  }
+  std::cout << std::endl;
   std::cout << "Battery Number: " << batteryNumber << std::endl;
 
   return 0;


### PR DESCRIPTION
Add support for multiple notification percentages for critical and low battery levels.

* **README.md**
  - Update the configuration file example to include `low_bat` and lists of percentages for `critical_bat` and `low_bat`.
  - Add descriptions for the new `low_bat` option and how to configure lists of percentages.

* **src/main.cpp**
  - Update the `Config` struct to include `std::vector<int> lowBatteryLevels` and change `criticalLevel` to `std::vector<int> criticalBatteryLevels`.
  - Modify the `readConfig` function to parse `critical_bat` and `low_bat` as lists of integers.
  - Add a helper function `parseBatteryLevels` to parse comma-separated battery levels.
  - Update the `getBatteryStatus` function to check against multiple critical and low battery levels.
  - Adjust the notification logic to handle multiple critical and low battery levels.
  - Update the `sendNotification` function to accept a custom message.

